### PR TITLE
[Bugfix] - custom_unit_amount fix for price sync

### DIFF
--- a/src/commands/sanitize/price.ts
+++ b/src/commands/sanitize/price.ts
@@ -33,6 +33,10 @@ export function sanitizePrice(
     delete data["currency_options"][data.currency];
   }
 
+  if (data['custom_unit_amount']) {
+    (data['custom_unit_amount'] as any)['enabled'] = true;
+  }
+
   data["product"] = newProductId;
 
   return data;


### PR DESCRIPTION
Currently, you'll see a `Missing required param: custom_unit_amount[enabled].` error if `custom_unit_amount` exists in the original price. 

The fix is to pass in [an extra enabled flag](https://stripe.com/docs/api/prices/create#create_price-custom_unit_amount-enabled) which exists outside of the `CustomUnitAmount` type.

Thanks for your work on this! It's already saved me a lot of headache troubleshooting various tier-related issues