### PR TITLE
Migrate quantity when re-creating subscriptions

### DIFF
--- a/src/commands/sanitize/subscription.ts
+++ b/src/commands/sanitize/subscription.ts
@@ -15,12 +15,18 @@ export function sanitizeSubscription(
   }
 
   // update price ids
-  const items: { price: string }[] = [];
+  const items: {
+    price: string,
+    quantity: number | undefined,
+  }[] = [];
   oldSubscription.items.data.forEach((item) => {
-    const price = prices.get(item.price.id);
+    const priceId = prices.get(item.price.id);
 
-    if (!price) throw Error("price_id does not exist");
-    items.push({ price });
+    if (!priceId) throw Error("price_id does not exist");
+    items.push({
+      price: priceId,
+      quantity: item.quantity,
+    });
   });
 
   if (typeof oldSubscription.customer !== "string") {


### PR DESCRIPTION
Currently when migrating subscription `items`, `quantity` is ignored and not migrated.

This change includes the `quantity` property of each `subscription.item` in the subscription that gets copied over.

---

Thank you for publishing all your work on this!