### PR TITLE
Add a new command to re-apply customer discount coupons

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ yarn start copy-promotion-codes 'path/to/coupons.csv' 'path/to/promotion-codes.c
 
 #### 4. Copy subscriptions
 
+# apply discount coupons to customers
+yarn start apply-customer-coupons 'path/to/coupons.csv' SOURCE_API_KEY TARGET_API_KEY
+
 # set default payment method of customer when it is not assigned yet
 yarn start set-default-payment-method TARGET_API_KEY
 

--- a/src/commands/apply-customer-coupons.ts
+++ b/src/commands/apply-customer-coupons.ts
@@ -1,0 +1,32 @@
+import { promises as fs } from "fs";
+import { csvStringToMap } from "../core/csv";
+import { createStripeClient } from "../core/stripe";
+
+export async function applyCustomerCoupons(
+  couponsFilePath: string,
+  apiKeyOldAccount: string,
+  apiKeyNewAccount: string,
+) {
+  const coupons = await csvStringToMap(
+    await fs.readFile(couponsFilePath, "utf8")
+  );
+
+  // https://stripe.com/docs/api/customers/list
+  await createStripeClient(apiKeyOldAccount)
+    .customers.list()
+    .autoPagingEach(async (customer) => {
+      if (customer.discount) {
+        const oldCouponId = customer.discount.coupon.id;
+        const newCouponId = coupons.get(oldCouponId as string);
+
+        if (!newCouponId) throw Error("No matching new coupon_id");
+
+        await createStripeClient(apiKeyNewAccount).customers.update(
+          customer.id,
+          {
+            coupon: newCouponId,
+          }
+        );
+      }
+    });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { hasApiSubscriptionWriteAccess } from "./commands/has-api-subscription-w
 import { pauseAllSubscriptions } from "./commands/pause-all-subscriptions";
 import { setDefaultPaymentMethod } from "./commands/set-default-payment-method";
 import { verifyAccount } from "./commands/verify-account";
+import { applyCustomerCoupons } from "./commands/apply-customer-coupons";
 
 async function main(action: string, args: string[]) {
   if (action === "verify-account") {
@@ -40,6 +41,8 @@ async function main(action: string, args: string[]) {
     await cancelAllSubscriptions(args[0]);
   } else if (action === "pause-all-subscriptions") {
     await pauseAllSubscriptions(args[0]);
+  } else if (action === "apply-customer-coupons") {
+    await applyCustomerCoupons(args[0], args[1], args[2]);
   } else {
     throw new Error("Unknown command");
   }


### PR DESCRIPTION
I've added a new command to re-apply the same customer discounts from the old account, to the customers in the new one.

* Call the new command with `apply-customer-coupons`, and the `coupons.csv` mapping, along with the api keys.
* Added a command example in the `README`, in the `Copy subscriptions` section.