### PR TITLE
Handle multi currency prices

### DIFF
--- a/src/commands/sanitize/price.ts
+++ b/src/commands/sanitize/price.ts
@@ -31,6 +31,12 @@ export function sanitizePrice(
 
   if (data["currency_options"]) {
     delete data["currency_options"][data.currency];
+    for (const currencyCode in data["currency_options"]) {
+      const currencyOption = data["currency_options"][currencyCode];
+      if ("unit_amount_decimal" in currencyOption) {
+        delete (currencyOption as any)["unit_amount_decimal"];
+      }
+    }
   }
 
   if (data['custom_unit_amount']) {


### PR DESCRIPTION
Importing prices with several currencies fail with error if "unit_amount_decimal" is not removed.